### PR TITLE
add nodejs 20 to testmatrix

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -48,12 +48,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          # Don't test Node.js 8 on Windows. npm is weird here
-          - os: windows-latest
-            node-version: 8.x
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
- add nodejs 20.x to testmatrix
- remove exception for node 8 on windows

Node 20 is officially released and adapters should support it. So testing on node 20.x is required in future. If the adapter fails on node 20.x feel free to suspend this PR but add a issue stating the problem and try ro fix it in the near future

exception for node 8 on windows is obsolete as no node 8 tests are run anymore anyway.