### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "type": "git",
     "url": "https://github.com/pixelit-project/ioBroker.pixelit"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "axios": "^1.3.2",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail on node 14 and lower as npm 6 does not install peerDependencies. So this adapter requires node 16 or newer.