### PR TITLE
Update test-and-release.yml - add node 22.x tests

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 21.x]
+        node-version: [18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
Your workflow tested againgt node 21.x which does not make much sense as node 22.x is stable in the meantime. So ioBroker adapter must be tested against node 22.x

I assume the 21.x was a typo - if not, please readd 21.x but keep node 22.x tests.